### PR TITLE
Make React a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "webpack": "^1.5.3",
     "webpack-dev-server": "^1.7.0"
   },
-  "dependencies": {
-    "react": "^0.12.2"
+  "peerDependencies": {
+    "react": ">=0.12.2"
   },
   "scripts": {
     "example": "webpack-dev-server --content-base example/ --config example/webpack.config.js --progress --hot --inline"

--- a/src/react-iscroll.js
+++ b/src/react-iscroll.js
@@ -179,7 +179,7 @@ var ReactIScroll = React.createClass({
 
   render: function() {
     return React.createElement("div", {className: this.props.className, style: this.props.style},
-             React.createElement("div", null, this.props.children)
+             React.createElement("div", {style: this.props.scrollerStyle}, this.props.children)
            )
   }
 })


### PR DESCRIPTION
Having react as hard dependency breaks the component when using React 0.13.3. It also bundles an additional copy of React when using with js module loaders such as webpack.
