### PR TITLE
Initialize immediately when there's no defer prop

### DIFF
--- a/src/react-iscroll.js
+++ b/src/react-iscroll.js
@@ -133,27 +133,27 @@ var ReactIScroll = React.createClass({
     var self = this;
     var init = function() {
       // Create iScroll instance with given options
-      self._iScrollInstance = new self.props.iscroll(self.getDOMNode(), self.props.options);
-      self._triggerRefreshEvent();
+      self._iScrollInstance = new self.props.iscroll(self.getDOMNode(), self.props.options)
+      self._triggerRefreshEvent()
 
       // Patch iscroll instance .refresh() function to trigger our onRefresh event
-      var origRefresh = self._iScrollInstance.refresh;
+      var origRefresh = self._iScrollInstance.refresh
       self._iScrollInstance.refresh = function() {
-        origRefresh.apply(self._iScrollInstance);
-        self._triggerRefreshEvent();
+        origRefresh.apply(self._iScrollInstance)
+        self._triggerRefreshEvent()
       }
 
       // Bind iScroll events
-      self._bindIScrollEvents();
+      self._bindIScrollEvents()
 
-      self._callQueuedCallbacks();
+      self._callQueuedCallbacks()
     };
 
-    if (this.props.defer && this.props.defer > 0) {
+    if (this.props.defer) {
       setTimeout(init, this.props.defer)
     }
     else {
-      init();
+      init()
     }
   },
 

--- a/src/react-iscroll.js
+++ b/src/react-iscroll.js
@@ -133,11 +133,13 @@ var ReactIScroll = React.createClass({
     var self = this;
     var init = function() {
       // Create iScroll instance with given options
+      var origRefresh;
+
       self._iScrollInstance = new self.props.iscroll(self.getDOMNode(), self.props.options)
       self._triggerRefreshEvent()
 
       // Patch iscroll instance .refresh() function to trigger our onRefresh event
-      var origRefresh = self._iScrollInstance.refresh
+      origRefresh = self._iScrollInstance.refresh
       self._iScrollInstance.refresh = function() {
         origRefresh.apply(self._iScrollInstance)
         self._triggerRefreshEvent()

--- a/src/react-iscroll.js
+++ b/src/react-iscroll.js
@@ -130,26 +130,31 @@ var ReactIScroll = React.createClass({
   },
 
   _initializeIScroll: function() {
-    var self = this,
-        origRefresh;
-
-    setTimeout(function() {
+    var self = this;
+    var init = function() {
       // Create iScroll instance with given options
-      self._iScrollInstance = new self.props.iscroll(self.getDOMNode(), self.props.options)
-      self._triggerRefreshEvent()
+      self._iScrollInstance = new self.props.iscroll(self.getDOMNode(), self.props.options);
+      self._triggerRefreshEvent();
 
       // Patch iscroll instance .refresh() function to trigger our onRefresh event
-      origRefresh = self._iScrollInstance.refresh
+      var origRefresh = self._iScrollInstance.refresh;
       self._iScrollInstance.refresh = function() {
-        origRefresh.apply(self._iScrollInstance)
-        self._triggerRefreshEvent()
+        origRefresh.apply(self._iScrollInstance);
+        self._triggerRefreshEvent();
       }
 
       // Bind iScroll events
-      self._bindIScrollEvents()
+      self._bindIScrollEvents();
 
-      self._callQueuedCallbacks()
-    }, this.props.defer)
+      self._callQueuedCallbacks();
+    };
+
+    if (this.props.defer && this.props.defer > 0) {
+      setTimeout(init, this.props.defer)
+    }
+    else {
+      init();
+    }
   },
 
   _callQueuedCallbacks: function() {


### PR DESCRIPTION
We've been having an issue in which an immediate redirect from a page with a `ReactIScroll` component causes a crash. `_teardownIScroll()` ends up getting called before the function in `setTimeout()`, so `this._iScrollInstance` is undefined when `destroy()` is called. So, this pull request just gives the option to defer or not, depending on whether `this.props.defer` is specified.

Love the library!
