### PR TITLE
using new non depreciated ReactDOM method

### DIFF
--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom';
 import equal from 'deep-equal'
 const { PropTypes } = React
 
@@ -139,7 +140,7 @@ export default class ReactIScroll extends React.Component {
 
     setTimeout(() => {
       // Create iScroll instance with given options
-      const iScrollInstance = new iScroll(React.findDOMNode(this), options)
+      const iScrollInstance = new iScroll(ReactDOM.findDOMNode(this), options)
       this._iScrollInstance = iScrollInstance
 
       // TODO there should be new event 'onInitialize'


### PR DESCRIPTION
from react v0.1.4 Upgrade guide:
https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html

Each of these changes will continue to work as before with a new warning until the release of 0.15 so you can upgrade your code gradually.
- Due to the DOM node refs change mentioned above, this.getDOMNode() is now deprecated and ReactDOM.findDOMNode(this) can be used instead. Note that in most cases, calling findDOMNode is now unnecessary – see the example above in the “DOM node refs” section.
