### PR TITLE
Fix exception on teardown

### DIFF
--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -184,8 +184,10 @@ export default class ReactIScroll extends React.Component {
   }
 
   _teardownIScroll() {
-    this._iScrollInstance.destroy()
-    this._iScrollInstance = undefined
+    if (this._iScrollInstance) {
+      this._iScrollInstance.destroy()
+      this._iScrollInstance = undefined
+    }
   }
 
   _bindIScrollEvents() {


### PR DESCRIPTION
Appears that in some corner cases `this._iScrollInstance` can be undefined which can definitively break the app
