### PR TITLE
Version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ var ExampleApp = React.createClass({
       options: {
         mouseWheel: true,
         scrollbars: true
-      },
-      wrapperStyle: {
-        position: 'absolute',
-        zIndex: '1',
-        top: '0',
-        bottom: '45px',
-        left: '0',
-        overflow: 'hidden',
       }
     })
   },
@@ -65,9 +57,9 @@ var ExampleApp = React.createClass({
     }
 
     return (
-      <div style={this.props.wrapperStyle}>
+      <div style={height: '100vh'}>
         <h1>Example of scrollable list</h1>
-        <ReactIScroll iscroll={iScroll}
+        <ReactIScroll iScroll={iScroll}
                       options={this.props.options}
                       onScrollStart={this.onScrollStart}>
           <ul>
@@ -87,7 +79,7 @@ Basic configuration. Just component with iScroll library. You can pick build whi
 ```js
 var iScroll = require('iscroll/build/iscroll-lite')
 
-<ReactIScroll iscroll={iScroll}>
+<ReactIScroll iScroll={iScroll}>
   <div>Long content...</div>
 </ReactIScroll>
 ```
@@ -105,7 +97,7 @@ var options = {
   indicators: {...}
 }
 
-<ReactIScroll iscroll={iScroll}
+<ReactIScroll iScroll={iScroll}
               options={options}>
   <div>Long content...</div>
 </ReactIScroll>
@@ -116,7 +108,7 @@ Component supports all iScroll events. All of them passed iScroll instance to ca
 ```js
 var iScroll = require('iscroll/build/iscroll-probe')
 
-<ReactIScroll iscroll={iScroll}
+<ReactIScroll iScroll={iScroll}
               onBeforeScrollStart={this.onBeforeScrollStart}
               onScrollCancel={this.onScrollCancel}
               onScrollStart={this.onScrollStart}
@@ -147,7 +139,7 @@ onRefresh: function(iScrollInstance) {
 },
 render: function() {
   return (
-    <ReactIScroll iscroll={iScroll}
+    <ReactIScroll iScroll={iScroll}
                   onRefresh={this.onRefresh}>
       <div>Long content...</div>
     </ReactIScroll>
@@ -177,7 +169,7 @@ You can pass `true` as first argument for call callback after iscroll is initial
       <div>
         <a class="#" onClick={this.onSomethingClick}>Do something</a>
         <ReactIScroll ref="iscroll"
-                      iscroll={iScroll}
+                      iScroll={iScroll}
                       onRefresh={this.onRefresh}>
           <div>Long content...</div>
         </ReactIScroll>
@@ -198,7 +190,7 @@ var React = require('react'),
 var HorizontalScroll = React.createClass({
   render: function() {
     return (
-      <ReactIScroll iscroll={iScroll}
+      <ReactIScroll iScroll={iScroll}
                     options={{mouseWheel: true, scrollbars: true, scrollX: true}}>
         <div style={{width:'200%'}}>
           <ul>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 React component for wrapping iScroll library.
 
+## ! Breaking changes in version 1.0.0
+
+- Property for passing iScroll instance is renamed from `iscroll` to `iScroll` and naming is unified across whole package
+  - use it like `<ReactIScroll iScroll={iScroll}>` instead of ~~`<ReactIScroll iscroll={iScroll}>`~~
+- Inner content wrapper is removed. https://github.com/schovi/react-iscroll/commit/ecd75bb75667a45d2e14a2eda0a1b7d56c9d54f4
+  - You can do it by yourself by wrapping childrens of ReactIScroll component into one more div with specific styling (check **Horizontal scroll example** there in README)
+  - Main iScroll element has same behaviour and you can still change styling with `style` and `className` properties.
 
 ### What is iScroll?
 

--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ Return iScroll instance if initialized
 ### function component.withIScroll([waitForInit], callback)
 
 Run callback with iScroll instance as argument if instance is initialized.
-You can pass `true` as first argument for call callback after iscroll is initialized
+You can pass `true` as first argument for call callback after iScroll is initialized
 
 ```js
   onSomethingClick: function(ev) {
     ev.preventDefault()
-    this.refs.iscroll.withIScroll(function(iscroll) {
-      iscroll.destroy()
+    this.refs.iScroll.withIScroll(function(iScroll) {
+      iScroll.destroy()
     })
   },
 
@@ -168,7 +168,7 @@ You can pass `true` as first argument for call callback after iscroll is initial
     return(
       <div>
         <a class="#" onClick={this.onSomethingClick}>Do something</a>
-        <ReactIScroll ref="iscroll"
+        <ReactIScroll ref="iScroll"
                       iScroll={iScroll}
                       onRefresh={this.onRefresh}>
           <div>Long content...</div>
@@ -219,8 +219,8 @@ There is example application. You can run it with this commands:
 
 ### Done
 - [x] Make this README.md :)
-- [x] Trigger `onRefresh` event when iscroll is internally refreshed (e.g. on window resize)
-- [x] Do not `require('iscroll')` by itself. Instead pass it in props (there is few different versions of iscroll and you want to pick correct one for you)
+- [x] Trigger `onRefresh` event when iScroll is internally refreshed (e.g. on window resize)
+- [x] Do not `require('iscroll')` by itself. Instead pass it in props (there is few different versions of iScroll and you want to pick correct one for you)
 - [x] Publish to npm
 - [x] Convert source code into Babel
 

--- a/README.md
+++ b/README.md
@@ -214,15 +214,16 @@ There is example application. You can run it with this commands:
 
 ## To-Do
 
-#### Done
+- [ ] Add tests
+- [ ] Think about `shouldComponentUpdate`. Now it is always true because `this.props.children` are new object everytime and can't be compared via `==` or `===`. Maybe there is some way how to cheaply compare them.
+- [ ] Don't initialize IScroll when there is no child supplied.
+
+### Done
 - [x] Make this README.md :)
 - [x] Trigger `onRefresh` event when iscroll is internally refreshed (e.g. on window resize)
 - [x] Do not `require('iscroll')` by itself. Instead pass it in props (there is few different versions of iscroll and you want to pick correct one for you)
 - [x] Publish to npm
 - [x] Convert source code into Babel
-
-- [ ] Add tests
-- [ ] Think about `shouldComponentUpdate`. Now it is always true because `this.props.children` are new object everytime and can't be compared via `==` or `===`. Maybe there is some way how to cheaply compare them.
 
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -179,6 +179,31 @@ You can pass `true` as first argument for call callback after iscroll is initial
   }
 ```
 
+## Horizonzal scroll
+
+Common usecase of horizontal scrolling
+
+```js
+var React = require('react'),
+    ReactIScroll = require('react-iscroll'),
+    iScroll = require('iscroll');
+
+var HorizontalScroll = React.createClass({
+  render: function() {
+    return (
+      <ReactIScroll iscroll={iScroll}
+                    options={{mouseWheel: true, scrollbars: true, scrollX: true}}>
+        <div style={{width:'200%'}}>
+          <ul>
+            {listOfLi}
+          </ul>
+        </div>
+      </ReactIScroll>
+    )
+  }
+})
+```
+
 ## Example
 
 There is example application. You can run it with this commands:

--- a/example/example.css
+++ b/example/example.css
@@ -98,6 +98,11 @@ li {
   border-top: 1px solid #fff;
   background-color: #fafafa;
   font-size: 14px;
+
+}
+
+.beyond {
+  float: right;
 }
 
 .button {

--- a/example/example.js
+++ b/example/example.js
@@ -75,7 +75,7 @@ class Example extends React.Component {
     let i = 0;
 
     for(i; i < len; i++) {
-      listOfLi.push(<li key={i}>Pretty row {this.state.list[i]}</li>)
+      listOfLi.push(<li key={i}>Pretty row {this.state.list[i]}<span className="beyond">I'm beyond</span></li>)
     }
 
     return (
@@ -89,11 +89,12 @@ class Example extends React.Component {
                         options={IScrollOptions}
                         onRefresh={this.onScrollRefresh}
                         onScrollStart={this.onScrollStart}
-                        onScrollEnd={this.onScrollEnd}
-                        scrollerStyle={{width: "200%"}}>
-            <ul>
-              {listOfLi}
-            </ul>
+                        onScrollEnd={this.onScrollEnd}>
+            <div style={{width: "110%"}}>
+              <ul>
+                {listOfLi}
+              </ul>
+            </div>
           </ReactIScroll>
         </div>
         <div id="footer">

--- a/example/example.js
+++ b/example/example.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import IScroll from 'iscroll'
+import iScroll from 'iscroll'
 
 import './example.css'
 import ReactIScroll from '../src/react-iscroll'
 
-const IScrollOptions = {
+const iScrollOptions = {
   mouseWheel: true,
   scrollbars: true,
   scrollX: true
@@ -35,8 +35,8 @@ class Example extends React.Component {
     this.setState({isScrolling: true})
   }
 
-  onScrollEnd = (IScrollInstance) => {
-    this.setState({isScrolling: false, y: IScrollInstance.y})
+  onScrollEnd = (iScrollInstance) => {
+    this.setState({isScrolling: false, y: iScrollInstance.y})
   }
 
   addRow = (ev) => {
@@ -61,8 +61,8 @@ class Example extends React.Component {
 
   }
 
-  onScrollRefresh = (IScrollInstance) => {
-    const hasVerticalScroll = IScrollInstance.hasVerticalScroll
+  onScrollRefresh = (iScrollInstance) => {
+    const hasVerticalScroll = iScrollInstance.hasVerticalScroll
 
     if(this.state.canVerticallyScroll !== hasVerticalScroll) {
       this.setState({canVerticallyScroll: hasVerticalScroll})
@@ -82,11 +82,11 @@ class Example extends React.Component {
       <div>
         <div id="header">
           <button onClick={this.removeRow} className="button">Remove first row</button>
-          React IScroll component example
+          React iScroll component example
         </div>
         <div id="wrapper">
-          <ReactIScroll IScroll={IScroll}
-                        options={IScrollOptions}
+          <ReactIScroll iScroll={iScroll}
+                        options={iScrollOptions}
                         onRefresh={this.onScrollRefresh}
                         onScrollStart={this.onScrollStart}
                         onScrollEnd={this.onScrollEnd}>

--- a/example/example.js
+++ b/example/example.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import IScroll from 'iscroll'
 
 import './example.css'
-import ReactIScroll from '../dist/react-iscroll'
+import ReactIScroll from '../src/react-iscroll'
 
 const IScrollOptions = {
   mouseWheel: true,

--- a/example/example.js
+++ b/example/example.js
@@ -33,11 +33,11 @@ class Example extends React.Component {
 
   onScrollStart = () => {
     this.setState({isScrolling: true})
-  }
+  };
 
   onScrollEnd = (iScrollInstance) => {
     this.setState({isScrolling: false, y: iScrollInstance.y})
-  }
+  };
 
   addRow = (ev) => {
     ev.preventDefault()
@@ -48,7 +48,7 @@ class Example extends React.Component {
     list.push(newId)
 
     this.setState({list: list, lastId: newId})
-  }
+  };
 
   removeRow = (ev) => {
     ev.preventDefault()
@@ -58,8 +58,7 @@ class Example extends React.Component {
     list.shift()
 
     this.setState({list: list})
-
-  }
+  };
 
   onScrollRefresh = (iScrollInstance) => {
     const hasVerticalScroll = iScrollInstance.hasVerticalScroll
@@ -67,7 +66,7 @@ class Example extends React.Component {
     if(this.state.canVerticallyScroll !== hasVerticalScroll) {
       this.setState({canVerticallyScroll: hasVerticalScroll})
     }
-  }
+  };
 
   render() {
     const listOfLi = [],

--- a/example/example.js
+++ b/example/example.js
@@ -3,7 +3,7 @@ import React from 'react'
 import ReactIScroll from '../dist/react-iscroll'
 import IScroll from 'iscroll'
 
-const iScrollOptions = {
+const IScrollOptions = {
   mouseWheel: true,
   scrollbars: true,
   scrollX: true
@@ -33,8 +33,8 @@ class Example extends React.Component {
     this.setState({isScrolling: true})
   }
 
-  onScrollEnd = (iscroll) => {
-    this.setState({isScrolling: false, y: iscroll.y})
+  onScrollEnd = (IScrollInstance) => {
+    this.setState({isScrolling: false, y: IScrollInstance.y})
   }
 
   addRow = (ev) => {
@@ -59,8 +59,8 @@ class Example extends React.Component {
 
   }
 
-  onScrollRefresh = (iscroll) => {
-    const hasVerticalScroll = iscroll.hasVerticalScroll
+  onScrollRefresh = (IScrollInstance) => {
+    const hasVerticalScroll = IScrollInstance.hasVerticalScroll
 
     if(this.state.canVerticallyScroll !== hasVerticalScroll) {
       this.setState({canVerticallyScroll: hasVerticalScroll})
@@ -83,8 +83,8 @@ class Example extends React.Component {
           React IScroll component example
         </div>
         <div id="wrapper">
-          <ReactIScroll iscroll={IScroll}
-                        options={iScrollOptions}
+          <ReactIScroll IScroll={IScroll}
+                        options={IScrollOptions}
                         onRefresh={this.onScrollRefresh}
                         onScrollStart={this.onScrollStart}
                         onScrollEnd={this.onScrollEnd}

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -14,7 +14,8 @@ module.exports = {
   },
 
   resolve: {
-    root: [ __dirname ]
+    root: [ __dirname ],
+    extensions: ['', '.js', '.jsx']
   },
 
   module: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iscroll",
-  "version": "1.0.0-beta1",
+  "version": "1.0.0-beta2",
   "homepage": "https://github.com/schovi/react-iscroll",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iscroll",
-  "version": "1.0.0-beta2",
+  "version": "1.0.0-beta.2",
   "homepage": "https://github.com/schovi/react-iscroll",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iscroll",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/schovi/react-iscroll",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iscroll",
-  "version": "0.1.5",
+  "version": "1.0.0-beta1",
   "homepage": "https://github.com/schovi/react-iscroll",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iscroll",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.2",
   "homepage": "https://github.com/schovi/react-iscroll",
   "keywords": [
     "react",

--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -50,9 +50,9 @@ for(var i = 0; i < availableEvents.length; i++) {
 
 export default class ReactIScroll extends React.Component {
 
-  static displayName = 'ReactIScroll'
+  static displayName = 'ReactIScroll';
 
-  static propTypes = propTypes
+  static propTypes = propTypes;
 
   static defaultProps = {
     defer: 0,
@@ -63,7 +63,7 @@ export default class ReactIScroll extends React.Component {
       width: "100%",
       overflow: "hidden"
     }
-  }
+  };
 
   constructor(props) {
     super(props)

--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -96,9 +96,7 @@ export default class ReactIScroll extends React.Component {
     } else {
       this.withIScroll(true, (iScrollInstance) => {
         // Save current state
-        const x     = iScrollInstance.x
-        const y     = iScrollInstance.y
-        const scale = iScrollInstance.scale
+        const {x, y, scale} = iScrollInstance
 
         // Destroy current and Create new instance of iScroll
         this._teardownIScroll()

--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -3,8 +3,8 @@ import ReactDOM from 'react-dom';
 import equal from 'deep-equal'
 const { PropTypes } = React
 
-// Events available on iScroll instance
-// [`iscroll event name`, `react component event name`]
+// Events available on IScroll instance
+// [`IScroll event name`, `react component event name`]
 const availableEvents = [
   ['beforeScrollStart', "onBeforeScrollStart"],
   ['scrollCancel', "onScrollCancel"],
@@ -23,19 +23,19 @@ const propTypes = {
     React.PropTypes.number
   ]),
   options: PropTypes.object,
-  iscroll: (props, propName, componentName) => {
-    const iscroll = props[propName]
-    const proto   = iscroll && iscroll.prototype
+  IScroll: (props, propName, componentName) => {
+    const IScroll = props[propName]
+    const proto   = IScroll && IScroll.prototype
 
-    if(!iscroll || !proto || !proto.version || !proto.scrollTo) {
-      return new Error(componentName + ": iscroll not passed to component props.")
+    if(!IScroll || !proto || !proto.version || !proto.scrollTo) {
+      return new Error(componentName + ": IScroll not passed to component props.")
     } else {
       if(!/^5\..*/.test(proto.version)) {
-        console.warn(componentName + ": different version than 5.x.y of iscroll is loaded. Some features won't work properly.")
+        console.warn(componentName + ": different version than 5.x.y of IScroll is required. Some features won't work properly.")
       }
 
       if(props.options && props.options.zoom && !proto.zoom) {
-        console.warn(componentName + ": options.zoom is set, but iscroll-zoom version is not loaded. This feature won't works properly.")
+        console.warn(componentName + ": options.zoom is set, but iscroll-zoom version is not required. Zoom feature won't work properly.")
       }
     }
   },
@@ -66,7 +66,7 @@ export default class ReactIScroll extends React.Component {
   constructor(props) {
     super(props)
     this._queuedCallbacks = []
-    this._iScrollBindedEvents = {}
+    this._IScrollBindedEvents = {}
   }
 
   componentDidMount() {
@@ -82,23 +82,23 @@ export default class ReactIScroll extends React.Component {
     return !equal(this.props, nextProps)
   }
 
-  // Check if iscroll options has changed and recreate instance with new one
+  // Check if IScroll options has changed and recreate instance with new one
   componentDidUpdate(prevProps) {
-    // If options are same, iscroll behaviour will not change. Just refresh events and trigger refresh
+    // If options are same, IScroll behaviour will not change. Just refresh events and trigger refresh
     if(equal(prevProps.options, this.props.options)) {
       this._updateIScrollEvents(prevProps, this.props)
       this.refresh()
 
-    // If options changed, we will destroy iScroll instance and create new one with same scroll position
+    // If options changed, we will destroy IScroll instance and create new one with same scroll position
     // TODO test if this will work with indicators
     } else {
-      this.withIScroll(true, (iScrollInstance) => {
+      this.withIScroll(true, (IScrollInstance) => {
         // Save current state
-        const x     = iScrollInstance.x
-        const y     = iScrollInstance.y
-        const scale = iScrollInstance.scale
+        const x     = IScrollInstance.x
+        const y     = IScrollInstance.y
+        const scale = IScrollInstance.scale
 
-        // Destroy current and Create new instance of iscroll
+        // Destroy current and Create new instance of IScroll
         this._teardownIScroll()
         this._initializeIScroll()
 
@@ -114,12 +114,12 @@ export default class ReactIScroll extends React.Component {
   }
 
   getIScroll() {
-    return this._iScrollInstance;
+    return this._IScrollInstance;
   }
 
   getIScrollInstance() {
     console.warn("Function 'getIScrollInstance' is deprecated. Instead use 'getIScroll'")
-    return this._iScrollInstance;
+    return this._IScrollInstance;
   }
 
   withIScroll(waitForInit, callback) {
@@ -135,28 +135,28 @@ export default class ReactIScroll extends React.Component {
   }
 
   refresh() {
-    this.withIScroll((iScroll) => iScroll.refresh())
+    this.withIScroll((IScrollInstance) => IScrollInstance.refresh())
   }
 
   _runInitializeIScroll() {
-    const {iscroll: iScroll, options} = this.props
+    const {IScroll, options} = this.props
 
-    // Create iScroll instance with given options
-    const iScrollInstance = new iScroll(ReactDOM.findDOMNode(this), options)
-    this._iScrollInstance = iScrollInstance
+    // Create IScroll instance with given options
+    const IScrollInstance = new IScroll(ReactDOM.findDOMNode(this), options)
+    this._IScrollInstance = IScrollInstance
 
     // TODO there should be new event 'onInitialize'
     this._triggerRefreshEvent()
 
-    // Patch iscroll instance .refresh() function to trigger our onRefresh event
-    const origRefresh = iScrollInstance.refresh
+    // Patch IScroll instance .refresh() function to trigger our onRefresh event
+    const origRefresh = IScrollInstance.refresh
 
-    iScrollInstance.refresh = () => {
-      origRefresh.apply(iScrollInstance)
+    IScrollInstance.refresh = () => {
+      origRefresh.apply(IScrollInstance)
       this._triggerRefreshEvent()
     }
 
-    // Bind iScroll events
+    // Bind IScroll events
     this._bindIScrollEvents()
 
     this._callQueuedCallbacks()
@@ -184,13 +184,13 @@ export default class ReactIScroll extends React.Component {
   }
 
   _teardownIScroll() {
-    this._iScrollInstance.destroy()
-    this._iScrollInstance = undefined
+    this._IScrollInstance.destroy()
+    this._IScrollInstance = undefined
   }
 
   _bindIScrollEvents() {
-    // Bind events on iScroll instance
-    this._iScrollBindedEvents = {}
+    // Bind events on IScroll instance
+    this._IScrollBindedEvents = {}
     this._updateIScrollEvents({}, this.props)
   }
 
@@ -199,29 +199,29 @@ export default class ReactIScroll extends React.Component {
     const len = availableEvents.length;
 
     for(let i = 0; i < len; i++) {
-      const [iScrollEventName, reactEventName] = availableEvents[i]
-      this._updateIScrollEvent(iScrollEventName, prevProps[reactEventName], nextProps[reactEventName])
+      const [IScrollEventName, reactEventName] = availableEvents[i]
+      this._updateIScrollEvent(IScrollEventName, prevProps[reactEventName], nextProps[reactEventName])
     }
   }
 
   // Unbind and/or Bind event if it was changed during update
-  _updateIScrollEvent(iScrollEventName, prevEvent, currentEvent) {
+  _updateIScrollEvent(IScrollEventName, prevEvent, currentEvent) {
     if(prevEvent !== currentEvent) {
-      this.withIScroll(true, (iScrollInstance) => {
-        const currentEvents = this._iScrollBindedEvents
+      this.withIScroll(true, (IScrollInstance) => {
+        const currentEvents = this._IScrollBindedEvents
 
         if(prevEvent) {
-          iScrollInstance.off(iScrollEventName, currentEvents[iScrollEventName])
-          currentEvents[iScrollEventName] = undefined
+          IScrollInstance.off(IScrollEventName, currentEvents[IScrollEventName])
+          currentEvents[IScrollEventName] = undefined
         }
 
         if(currentEvent) {
           const wrappedCallback = function(...args) {
-            currentEvent(iScrollInstance, ...args)
+            currentEvent(IScrollInstance, ...args)
           }
 
-          iScrollInstance.on(iScrollEventName, wrappedCallback)
-          currentEvents[iScrollEventName] = wrappedCallback
+          IScrollInstance.on(IScrollEventName, wrappedCallback)
+          currentEvents[IScrollEventName] = wrappedCallback
         }
       })
     }
@@ -231,7 +231,7 @@ export default class ReactIScroll extends React.Component {
     const {onRefresh} = this.props
 
     if(onRefresh) {
-      this.withIScroll((iScrollInstance) => onRefresh(iScrollInstance))
+      this.withIScroll((IScrollInstance) => onRefresh(IScrollInstance))
     }
   }
 

--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -236,12 +236,15 @@ export default class ReactIScroll extends React.Component {
   }
 
   render() {
-    return (
-      <div className={this.props.className} style={this.props.style}>
-        <div style={this.props.scrollerStyle}>
-          {this.props.children}
-        </div>
-      </div>
-    )
+    // Keep only html properties
+    const htmlProps = {}
+
+    for(const prop in this.props) {
+      if(!propTypes[prop]) {
+        htmlProps[prop] = this.props[prop]
+      }
+    }
+
+    return <div {...htmlProps} />
   }
 }


### PR DESCRIPTION
I think it is about time to move step forward with 1.0.0 version. You can load this changes in your package.json with this version `1.0.0-beta1`

Some important breaking changes
- Property for passing iScroll instance is renamed from `iscroll` to `iScroll` and naming is unified across whole package
  - use it like `<ReactIScroll iScroll={iScroll}>` instead of ~~`<ReactIScroll iscroll={iScroll}>`~~
- Inner content wrapper is removed. https://github.com/schovi/react-iscroll/commit/ecd75bb75667a45d2e14a2eda0a1b7d56c9d54f4
  - You can do it by yourself by wrapping childrens of ReactIScroll component into one more div with specific styling (check [**Horizontal scroll example**](https://github.com/schovi/react-iscroll/blob/version/1.0.0/README.md#horizonzal-scroll) )
  - Main iScroll element has same behaviour and you can still change styling with `style` and `className` properties.
