### PR TITLE
added tap / click elements example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,37 @@ var HorizontalScroll = React.createClass({
 })
 ```
 
+## Tap / Click Elements inside IScroll
+
+To override the native scrolling iScroll has to inhibit some default browser behaviors, such as mouse clicks. See [iScroll manual](http://iscrolljs.com/) options.click and options.tap. The following is an example of including a clickable element.
+
+```js
+constructor(props) {
+    super(props);
+    this.refDict = {};
+}
+
+componentDidMount() {
+    this.refDict[0].addEventListener("tap", () => this.handleTap(this.refDict[0]));
+}
+
+handleTap(e) {
+    console.log(e.id);
+}
+
+render(){
+    return(
+        <ReactIScroll iScroll={iScroll}>
+            <div>
+                <div id={0} ref={el => this.refDict[0] = el}>
+                Click me in react-iscroll
+                </div>
+            </div>
+        </ReactIScroll>
+    )
+}
+```
+
 ## Example
 
 There is example application. You can run it with this commands:

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ To override the native scrolling iScroll has to inhibit some default browser beh
 ```js
 constructor(props) {
     super(props);
-    this.refDict = {};
+    this.refDict = [];
 }
 
 componentDidMount() {
@@ -230,7 +230,11 @@ handleTap(e) {
 
 render(){
     return(
-        <ReactIScroll iScroll={iScroll}>
+        <ReactIScroll iScroll={iScroll}
+              options={{
+                tap: true
+              }}
+              >
             <div>
                 <div id={0} ref={el => this.refDict[0] = el}>
                 Click me in react-iscroll


### PR DESCRIPTION
It took me a little to figure out how to implement the click / tap functionality in react so I thought it would be helpful to add react specific code to the documentation. Let me know if you think so too.