### PR TITLE
Replace ReactDOM.findDOMNode() with ref.

### DIFF
--- a/src/react-iscroll.jsx
+++ b/src/react-iscroll.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
 import deepEqual from 'deep-equal'
 
 const excludePropNames = ['defer', 'iScroll', 'onRefresh', 'options']
@@ -33,6 +32,7 @@ export default class ReactIScroll extends React.Component {
   constructor(props) {
     super(props)
 
+    this._node = null
     this._isMounted = false
     this._initializeTimeout = null
     this._queuedCallbacks = []
@@ -113,7 +113,7 @@ export default class ReactIScroll extends React.Component {
     const { iScroll, options } = this.props
 
     // Create iScroll instance with given options
-    const iScrollInstance = new iScroll(ReactDOM.findDOMNode(this), options)
+    const iScrollInstance = new iScroll(this._node, options)
     this._iScrollInstance = iScrollInstance
 
     this._triggerInitializeEvent(iScrollInstance)
@@ -247,7 +247,7 @@ export default class ReactIScroll extends React.Component {
       }
     }
 
-    return <div {...props} />
+    return <div ref={node => this._node = node} {...props} />
   }
 }
 


### PR DESCRIPTION
Replaced findDOMNode with refs which is a more explicit and preferred method of accessing underlying DOM nodes. See:

https://reactjs.org/docs/react-dom.html#finddomnode
https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage
https://github.com/yannickcr/eslint-plugin-react/issues/678

Incidentally, this also resolves [issue #70](https://github.com/schovi/react-iscroll/issues/70) where the "Unable to find node on an unmounted component" exception is thrown possibly due to different libraries using different versions of react-dom in the same project.